### PR TITLE
Add implementation plan and help file punchlist

### DIFF
--- a/COOKBOOK_PLAN.MD
+++ b/COOKBOOK_PLAN.MD
@@ -1,0 +1,119 @@
+# TinTin++ Cookbook Implementation Plan
+
+## Objective
+Develop a comprehensive reference so an AI agent can script TinTin++ to automate exploring, questing, combat, and data workflows in a latency-prone text RPG with rich chat and crafting systems.
+
+## Plan Overview
+1. **Catalog native commands**: For each topic listed in the help files create `<command>.md` with a brief intro and multiple syntax examples. Use `rg` to collect examples from `help_files` and the `3stepper`, `byron`, and `inix` repositories, filtering duplicates.
+2. **Mapping and exploration**: Document best practices for `#map`, pathfinding, and speedwalking while handling variable latency and random events.
+3. **Combat and quest automation**: Cover triggers, loops, and state tracking to keep characters in continuous combat and manage quests or guild experience.
+4. **Data collection and analysis**: Show how to log data, run scripts, and execute SQL queries for telemetry and decision making.
+5. **User interface enhancements**: Describe methods for layout, chat windows, prompts, color usage, and accessibility features.
+6. **Comparative study**: Summarize advanced features from `3stepper`, `byron`, and `inix`, noting where their approaches diverge or complement each other.
+7. **Iteration**: As documentation sections are completed, update this plan to track progress and outstanding work.
+
+## Help File Punchlist
+- action
+- cat
+- coordinates
+- echo
+- foreach
+- history
+- line
+- mapping
+- nop
+- regexp
+- script
+- ssl
+- textin
+- alias
+- characters
+- cr
+- edit
+- format
+- if
+- list
+- math
+- parse
+- repeat
+- send
+- statements
+- ticker
+- all
+- chat
+- cursor
+- editing
+- function
+- ignore
+- lists
+- mathematics
+- path
+- replace
+- session
+- substitute
+- time
+- bell
+- class
+- daemon
+- else
+- gag
+- index
+- local
+- message
+- pathdir
+- return
+- sessionname
+- substitutions
+- triggers
+- break
+- colors
+- debug
+- elseif
+- greeting
+- info
+- log
+- metric_system
+- pcre
+- run
+- showme
+- suspend
+- variable
+- buffer
+- commands
+- default
+- end
+- grep
+- introduction
+- loop
+- mouse
+- port
+- scan
+- snoop
+- switch
+- while
+- button
+- config
+- delay
+- escape_codes
+- help
+- keypad
+- macro
+- msdp
+- prompt
+- screen
+- speedwalk
+- system
+- write
+- case
+- continue
+- draw
+- event
+- highlight
+- kill
+- map
+- mslp
+- read
+- screen_reader
+- split
+- tab
+- zap


### PR DESCRIPTION
## Summary
- Outline cookbook goals and workflow for documenting TinTin++ automation strategies.
- Add punchlist of all TinTin++ help topics to track command coverage.

## Testing
- `bash clean_help_files.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa8f3551e8833095a38baec86d4152