### PR TITLE
Refine cookbook plan and document action command

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -36,3 +36,22 @@ For each entry in the help files we need to create a <command_name>.md file in s
 Next we'll compile a comparative feature list across all three implementations and I'll direct comparative studies of how each implemented those systems. 
 
 Finally, we'll explore design patterns and possible implementations.
+
+### Section drafting checklist
+
+When adding a new command section to the cookbook, follow these steps to keep
+examples consistent and well‑researched:
+
+1. **Start from the help file** – review the cleaned TinTin++ help text as the
+   baseline description.
+2. **Search the repository** – use `rg` across `commands/` and the included
+   reference repos to gather diverse syntax examples.
+3. **Filter duplicates** – omit patterns already covered in other sections and
+   highlight novel usage, such as `#line` for one‑shot triggers or PCRE
+   captures.
+4. **Cross‑reference related commands** – link to regex/PCRE documentation or
+   other relevant sections where helpful.
+5. **Show runnable snippets** – prefer examples that can be copy‑pasted into a
+   TinTin++ session without additional context.
+6. **Update the plan and run tests** – mark the command as documented in
+   `COOKBOOK_PLAN.MD` and execute `bash clean_help_files.sh` before committing.

--- a/COOKBOOK_PLAN.MD
+++ b/COOKBOOK_PLAN.MD
@@ -1,0 +1,121 @@
+# TinTin++ Cookbook Implementation Plan
+
+## Objective
+Develop a comprehensive reference so an AI agent can script TinTin++ to automate exploring, questing, combat, and data workflows in a latency-prone text RPG with rich chat and crafting systems.
+
+## Plan Overview
+1. **Catalog native commands**: For each topic listed in the help files create `<command>.md` with a brief intro and multiple syntax examples. Use `rg` to collect examples from `help_files` and the `3stepper`, `byron`, and `inix` repositories, filtering duplicates. Start with the `#action` / `#act` trigger command.
+2. **Mapping**: Document best practices for `#map`, pathfinding, and speedwalking while handling variable latency and random events.
+3. **MIP interface**: Explain how to capture and parse server-sent data that bypasses the main display using the MUD Interface Protocol.
+4. **Exploration**: Cover automated movement, random event handling, and recovery from failed moves.
+5. **Combat and quest automation**: Cover triggers, loops, and state tracking to keep characters in continuous combat and manage quests or guild experience.
+6. **Data collection and analysis**: Show how to log data, run scripts, and execute SQL queries for telemetry and decision making.
+7. **User interface enhancements**: Describe methods for layout, chat windows, prompts, color usage, and accessibility features.
+8. **Comparative study**: Summarize advanced features from `3stepper`, `byron`, and `inix`, noting where their approaches diverge or complement each other.
+9. **Iteration**: As documentation sections are completed, update this plan to track progress and outstanding work.
+
+## Help File Punchlist
+- action (documented)
+- cat
+- coordinates
+- echo
+- foreach
+- history
+- line
+- mapping
+- nop
+- regexp
+- script
+- ssl
+- textin
+- alias
+- characters
+- cr
+- edit
+- format
+- if
+- list
+- math
+- parse
+- repeat
+- send
+- statements
+- ticker
+- all
+- chat
+- cursor
+- editing
+- function
+- ignore
+- lists
+- mathematics
+- path
+- replace
+- session
+- substitute
+- time
+- bell
+- class
+- daemon
+- else
+- gag
+- index
+- local
+- message
+- pathdir
+- return
+- sessionname
+- substitutions
+- triggers
+- break
+- colors
+- debug
+- elseif
+- greeting
+- info
+- log
+- metric_system
+- pcre
+- run
+- showme
+- suspend
+- variable
+- buffer
+- commands
+- default
+- end
+- grep
+- introduction
+- loop
+- mouse
+- port
+- scan
+- snoop
+- switch
+- while
+- button
+- config
+- delay
+- escape_codes
+- help
+- keypad
+- macro
+- msdp
+- prompt
+- screen
+- speedwalk
+- system
+- write
+- case
+- continue
+- draw
+- event
+- highlight
+- kill
+- map
+- mslp
+- read
+- screen_reader
+- split
+- tab
+- zap

--- a/commands/action.md
+++ b/commands/action.md
@@ -1,0 +1,53 @@
+# action / act
+
+The `#action` command (abbreviated `#act`) creates triggers that execute TinTin++ commands when incoming text matches a pattern. Patterns use Perl-compatible regular expressions, so see the `regex` and `pcre` sections for full syntax support.
+
+## Syntax
+```
+#action {pattern} {commands} {priority}
+```
+
+## Examples
+
+- Auto-reply to tells:
+
+```tintin
+#action {%1 tells you '%2'} {tell %1 I'm afk.}
+```
+
+- Conditional response based on captured numbers:
+
+```tintin
+#action {%0 gives you %1 gold coins.} {#if {%1 > 5000} {thank %0}}
+```
+
+- Logging chat messages into a list:
+
+```tintin
+#action {%1 chats %2} {#list chats add {%0}}
+```
+
+- PCRE pattern with numerical capture:
+
+```tintin
+#act {%* says 'Who is number {[1-9][0-9]{0,2}}?} {say $number[%2] is number %2}
+```
+
+- Trigger that rings a bell when someone tells you:
+
+```tintin
+#action {Bubba tells you} {#bell}
+```
+
+- One-shot trigger using `#line`:
+
+```tintin
+#line oneshot {#action {^You receive %0 experience} {updatexp %0}}
+```
+
+## Notes
+
+- Use `#line oneshot` or `#line multishot` to control trigger lifetime.
+- Patterns are evaluated using PCRE, allowing groups, alternations, and anchors.
+- The optional `priority` argument sets trigger evaluation order.
+- Combine with `#regex` or `#pcre` for complex matching.


### PR DESCRIPTION
## Summary
- Insert MUD Interface Protocol coverage between mapping and exploration in the implementation plan and mark the action command as documented.
- Add a dedicated `action`/`act` section with diverse trigger examples, including PCRE patterns and one-shot `#line` usage.
- Clarify the section drafting process in `AGENTS.MD` with a step-by-step checklist for finding and recording examples.

## Testing
- `PATH=/usr/bin:/bin /bin/bash clean_help_files.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aa8f3551e8833095a38baec86d4152