### PR TITLE
Add documentation for cat, coordinates, and echo commands

### DIFF
--- a/COOKBOOK_PLAN.MD
+++ b/COOKBOOK_PLAN.MD
@@ -17,9 +17,9 @@ Develop a comprehensive reference so an AI agent can script TinTin++ to automate
 ## Help File Punchlist
 - action (documented)
 
-- cat
-- coordinates
-- echo
+- cat (documented)
+- coordinates (documented)
+- echo (documented)
 - foreach
 - history
 - line

--- a/commands/cat.md
+++ b/commands/cat.md
@@ -1,0 +1,30 @@
+# cat
+
+The `#cat` command concatenates an argument to the end of a variable.
+
+## Syntax
+```tintin
+#cat {variable} {argument}
+```
+
+## Examples
+
+- Append text to a variable:
+
+```tintin
+#variable {greeting} {Hello}
+#cat {greeting} {, world!}
+#show $greeting
+```
+
+- Merge two tables:
+
+```tintin
+#variable {bli} {{a}{1}{b}{2}}
+#variable {blo} {{c}{3}{d}{4}}
+#cat {blo} {$bli}
+```
+
+## Notes
+
+- Works with strings, lists, and tables.

--- a/commands/coordinates.md
+++ b/commands/coordinates.md
@@ -1,0 +1,40 @@
+# coordinates
+
+TinTin++ uses multiple coordinate styles for screen positions, map locations, and ranges.
+
+## Examples
+
+- Row/column (y,x) for screen positions:
+
+```tintin
+#showme {HP: 100} {1,1}
+```
+
+- Map coordinates (x,y,z):
+
+```tintin
+#map jump 10 5 0
+```
+
+- Square region defined by two corners:
+
+```tintin
+#draw Blue box 1 1 3 20 {Hello world!}
+```
+
+- Pane sizes (top, bottom, left, right):
+
+```tintin
+#split 1 1 0 -80
+```
+
+- Range bounds (upper and lower):
+
+```tintin
+#buffer {get} {lines} {1} {10}
+```
+
+## Notes
+
+- y,x notation starts at 1,1 in the upper-left.
+- Negative values count from the bottom or right edges.

--- a/commands/echo.md
+++ b/commands/echo.md
@@ -1,0 +1,39 @@
+# echo
+
+The `#echo` command prints formatted text to the local screen without sending it to the MUD.
+
+## Syntax
+```tintin
+#echo {format} {argument1} {argument2} {etc}
+```
+
+## Examples
+
+- Display the current date:
+
+```tintin
+#echo {The current date is %t.} {%Y-%m-%d %H:%M:%S}
+```
+
+- Format two strings with padding:
+
+```tintin
+#echo {[%38s][%-38s]} {Hello World} {Hello World}
+```
+
+- Print on a specific row:
+
+```tintin
+#echo {{this is %s on the top row} {1}} {printed}
+```
+
+- Triggered echo from an event:
+
+```tintin
+#event {RECEIVED OUTPUT} {#echo <058>%+80h BLOCK}
+```
+
+## Notes
+
+- Does not trigger actions.
+- Split the format argument into two braces to set the row number.


### PR DESCRIPTION
## Summary
- Document `#cat` command with variable concatenation examples.
- Add `coordinates` reference covering screen, map, square, pane, and range arguments.
- Document `#echo` command with formatting and event-based examples.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa92f93614833086a84f96dbd8d8ab